### PR TITLE
Fix: Add GitHub Actions Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+gem "github-pages", group: :jekyll_plugins


### PR DESCRIPTION
## Summary

- Add `.github/workflows/pages.yml` GitHub Actions workflow for Jekyll site deployment
- Add `Gemfile` with `github-pages` gem for proper dependency resolution

## Problem

The legacy GitHub Pages builder was timing out and erroring on claude-skills-guide's 2,501 articles. The build has been stuck in ERRORED state.

## Solution

All other fleet content repos (chrome-tips, chrome-extension-guide, ai-tools-compared, remote-work-tools, privacy-tools-guide) already use a GitHub Actions workflow for Pages deployment, which handles large sites without timeout issues. This PR adds the same workflow to claude-skills-guide.

The workflow uses:
- `actions/checkout@v4`
- `actions/configure-pages@v5`
- `actions/jekyll-build-pages@v1`
- `actions/upload-pages-artifact@v3`
- `actions/deploy-pages@v4`

With a 30-minute build timeout, matching the other repos.

## Post-merge steps

After merging, the repo's GitHub Pages settings need to be switched from "Deploy from a branch" to "GitHub Actions" under Settings > Pages > Build and deployment > Source.

## Test plan

- [ ] Verify workflow file matches working repos (chrome-tips, ai-tools-compared)
- [ ] After merge, switch Pages source to GitHub Actions in repo settings
- [ ] Trigger workflow manually via workflow_dispatch to verify build succeeds
- [ ] Confirm site is accessible at https://theluckystrike.github.io/claude-skills-guide/

🤖 Generated with [Claude Code](https://claude.com/claude-code)