### PR TITLE
Add cross-site navigation footer for SEO

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,5 +48,18 @@
   <header><a href="{{ site.baseurl }}/">{{ site.title }}</a></header>
   <main>{{ content }}</main>
   <footer>Built by theluckystrike — More tips at <a href="https://zovo.one">zovo.one</a></footer>
+  <div class="site-nav-footer" style="background:#f8f9fa;padding:20px;margin-top:40px;border-top:2px solid #e9ecef;text-align:center;">
+    <p style="margin-bottom:10px;font-weight:bold;color:#333;">Explore Our Developer Guides</p>
+    <nav>
+      <a href="https://theluckystrike.github.io/" style="margin:0 8px;color:#0366d6;text-decoration:none;">Home</a> &middot;
+      <a href="https://theluckystrike.github.io/chrome-tips/" style="margin:0 8px;color:#0366d6;text-decoration:none;">Chrome Tips</a> &middot;
+      <a href="https://theluckystrike.github.io/chrome-extension-guide/" style="margin:0 8px;color:#0366d6;text-decoration:none;">Extension Guide</a> &middot;
+      <a href="https://theluckystrike.github.io/claude-skills-guide/" style="margin:0 8px;color:#0366d6;text-decoration:none;">Claude Skills</a> &middot;
+      <a href="https://theluckystrike.github.io/ai-tools-compared/" style="margin:0 8px;color:#0366d6;text-decoration:none;">AI Tools</a> &middot;
+      <a href="https://theluckystrike.github.io/remote-work-tools/" style="margin:0 8px;color:#0366d6;text-decoration:none;">Remote Work</a> &middot;
+      <a href="https://theluckystrike.github.io/privacy-tools-guide/" style="margin:0 8px;color:#0366d6;text-decoration:none;">Privacy Tools</a>
+    </nav>
+    <p style="margin-top:10px;font-size:0.85em;color:#666;">&copy; 2026 <a href="https://theluckystrike.github.io/" style="color:#666;">theluckystrike Developer Guides</a></p>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds a cross-site navigation footer to the `default.html` layout
- Links to all 6 sub-sites (Chrome Tips, Extension Guide, Claude Skills, AI Tools, Remote Work, Privacy Tools) plus the hub homepage
- Uses absolute URLs for proper cross-domain SEO linking
- Appended after the existing footer, preserving all current layout functionality

## Test plan
- [ ] Verify the footer renders correctly on all pages
- [ ] Confirm all 7 links (hub + 6 sub-sites) resolve correctly
- [ ] Check mobile responsiveness of the nav footer

Generated with Claude Code