### PR TITLE
Fix nested raw tags causing Liquid build failure

### DIFF
--- a/articles/ai-inbox-organizer-chrome-extension.md
+++ b/articles/ai-inbox-organizer-chrome-extension.md
@@ -1,22 +1,14 @@
 ---
 layout: default
-raw %}
-author: "Claude Skills Guide"
-reviewed: true
-score: 8
-date: 2026-03-15
-categories: [guides]
-tags: [claude-code, claude-skills]
-permalink: /ai-inbox-organizer-chrome-extension/
----
-
-
-layout: default
 title: "AI Inbox Organizer Chrome Extension: A Developer's Guide to Intelligent Email Management"
 description: "Learn how AI inbox organizer Chrome extensions work under the hood. Practical implementation guide for developers building email automation tools."
 date: 2026-03-15
-author: theluckystrike
+author: "Claude Skills Guide"
 permalink: /ai-inbox-organizer-chrome-extension/
+categories: [guides]
+tags: [claude-code, claude-skills]
+reviewed: true
+score: 8
 ---
 {% raw %}
 # AI Inbox Organizer Chrome Extension: A Developer's Guide to Intelligent Email Management

--- a/articles/chatgpt-for-google-chrome-extension.md
+++ b/articles/chatgpt-for-google-chrome-extension.md
@@ -1,21 +1,14 @@
 ---
 layout: default
-raw %}
-author: "Claude Skills Guide"
-reviewed: true
-score: 8
-date: 2026-03-15
-categories: [guides]
-tags: [claude-code, claude-skills]
-permalink: /chatgpt-for-google-chrome-extension/
----
-
-layout: default
 title: "ChatGPT for Google Chrome Extension: A Developer Guide"
 description: "Learn how to integrate ChatGPT into Chrome extensions, build AI-powered features, and create custom implementations for enhanced productivity."
 date: 2026-03-15
-author: theluckystrike
+author: "Claude Skills Guide"
 permalink: /chatgpt-for-google-chrome-extension/
+categories: [guides]
+tags: [claude-code, claude-skills]
+reviewed: true
+score: 8
 ---
 {% raw %}
 # ChatGPT for Google Chrome Extension: A Developer Guide

--- a/articles/claude-code-for-fiber-go-web-framework-workflow.md
+++ b/articles/claude-code-for-fiber-go-web-framework-workflow.md
@@ -1,8 +1,7 @@
 ---
-
 layout: default
 title: "Claude Code for Fiber Go Web Framework Workflow"
-description: "Learn how to integrate Claude Code into your Fiber Go web framework development workflow for enhanced productivity and efficient coding.
+description: "Learn how to integrate Claude Code into your Fiber Go web framework development workflow for enhanced productivity and efficient coding."
 date: 2026-03-15
 author: Claude Skills Guide
 permalink: /claude-code-for-fiber-go-web-framework-workflow/

--- a/articles/claude-code-for-runbook-authoring-workflow-tutorial.md
+++ b/articles/claude-code-for-runbook-authoring-workflow-tutorial.md
@@ -116,11 +116,9 @@ When authoring, mark executable sections clearly:
 
 Run the following to check current database connections:
 
-{% raw %}
 ```bash
 psql -h $DB_HOST -U $DB_USER -c "SELECT datname, count(*) FROM pg_stat_activity GROUP BY datname;"
 ```
-{% endraw %}
 ```
 
 ### Integrating Monitoring Links


### PR DESCRIPTION
## Summary
- **Critical fix**: Remove inner `{% raw %}`/`{% endraw %}` pair nested inside the outer raw block in `claude-code-for-runbook-authoring-workflow-tutorial.md`, which caused a Liquid syntax error (`Unknown tag 'endraw'` on line 207) and broke the GitHub Pages build
- **YAML frontmatter fix**: Remove blank line and close unclosed description quote in `claude-code-for-fiber-go-web-framework-workflow.md`
- **YAML frontmatter fix**: Merge duplicate/corrupted frontmatter blocks in `chatgpt-for-google-chrome-extension.md` and `ai-inbox-organizer-chrome-extension.md` (both had stray `raw %}` lines and two frontmatter sections)

## Test plan
- [ ] Verify GitHub Pages build succeeds without Liquid syntax errors
- [ ] Confirm all four affected articles render correctly
- [ ] Verify outer `{% raw %}` tags are preserved (required per project rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)